### PR TITLE
chore: align editorconfig with other fdawgs repos

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,17 @@ max_line_length = 120
 [*.{yaml,yml}]
 indent_style = space
 
+# Built/generated files
+[{.devcontainer/devcontainer-lock.json,.github/release-please/manifest.json,CHANGELOG.md,dist/**,package-lock.json,types/**}]
+charset = unset
+end_of_line = unset
+indent_size = unset
+indent_style = unset
+insert_final_newline = unset
+max_line_length = unset
+trim_trailing_whitespace = unset
+
+# Test files
 [test/{fixtures,__snapshots__}/**]
 charset = unset
 end_of_line = unset


### PR DESCRIPTION
Updates `.editorconfig` unset block to cover all generated/external files, aligning with the rest of my repos.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
